### PR TITLE
Plantilla para la conexión a la base de datos

### DIFF
--- a/layout/php/connection.php
+++ b/layout/php/connection.php
@@ -1,0 +1,29 @@
+<?php
+	/*
+	$DB_host = El host del servidor, en este caso localhost
+	$DB_user = El usuario
+	$DB_password = La contraseña
+	*/
+	$DB_host = "127.0.0.1";
+	$DB_user = "root";
+	$DB_password = "";
+	$DB_name = "CarRentalSystem";
+
+	/*
+	Init the connection
+	*/
+	$link = mysql_connect($DB_host, $DB_user, $DB_password)
+		or die("Could not connect to the database, ".mysql_error());
+	echo "Connected successfully";
+
+	/*
+	Select the data base
+	*/
+	mysql_select_db($DB_name)
+		or die("Couldn't select the database.");
+
+	/*
+	Set the default character set for the current connection.
+	*/
+	mysql_query("SET NAMES 'utf8'");
+?>


### PR DESCRIPTION
Se anexa una plantilla para la conexión a la base de datos. Así, solo
poner en cada .php lo siguiente:
require("connection.php");
y ya no se tendrá que declarar la conexión cada vez que se requiera
hacer una consulta.
